### PR TITLE
Fixed installer ticket #54

### DIFF
--- a/Installer/check_for_mail.sh
+++ b/Installer/check_for_mail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "" == "`ps waux|grep Mail.app|grep -v grep`" ]; then
+if [ "" == "`ps waux|grep /Mail.app/|grep -v grep`" ]; then
     exit 0;
 else
     exit 1;


### PR DESCRIPTION
See http://gpgtools.lighthouseapp.com/projects/65162-installer/tickets/54

Changed the regexp so that it matches only /Mail.app/ and not also other applications that have Mail.app in its name, for example DavMail.app.
