### PR TITLE
Fix event storms in MADecodeWithContext and MAVerifySignature

### DIFF
--- a/GPGMail.xcodeproj/project.pbxproj
+++ b/GPGMail.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		303F16161500EB5C002AC36B /* NSButton+LinkCursor.m in Sources */ = {isa = PBXBuildFile; fileRef = 303F16151500EB5C002AC36B /* NSButton+LinkCursor.m */; };
 		30744AB512B9733800CC3EC5 /* MessageContentController+GPGMail.m in Sources */ = {isa = PBXBuildFile; fileRef = 559A808C0838EA1C0052F47C /* MessageContentController+GPGMail.m */; };
 		30E6857B13FFAC0800563BA5 /* GPGVersionComparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 30E6857A13FFAC0800563BA5 /* GPGVersionComparator.m */; };
+		45E7111E15064ECB00407F7D /* MimePartResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 45E7111D15064ECB00407F7D /* MimePartResult.m */; };
 		559A81300838EEFD0052F47C /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559A812B0838EEFD0052F47C /* AddressBook.framework */; };
 		559A81310838EEFD0052F47C /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559A812C0838EEFD0052F47C /* Carbon.framework */; };
 		559A81320838EEFD0052F47C /* Message.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559A812D0838EEFD0052F47C /* Message.framework */; };
@@ -1366,6 +1367,8 @@
 		30FC04EC14FFE61100AA19FE /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/GPGSignatureView.xib.strings; sourceTree = "<group>"; };
 		30FC04EE14FFE61100AA19FE /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/SignatureView.strings; sourceTree = "<group>"; };
 		32DBCF630370AF2F00C91783 /* GPGMail_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GPGMail_Prefix.pch; sourceTree = "<group>"; };
+		45E7111C15064EBE00407F7D /* MimePartResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MimePartResult.h; sourceTree = "<group>"; };
+		45E7111D15064ECB00407F7D /* MimePartResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MimePartResult.m; sourceTree = "<group>"; };
 		559A80550838E8300052F47C /* GPGMailPreferences.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = GPGMailPreferences.h; sourceTree = "<group>"; };
 		559A805D0838E8300052F47C /* MimeBody+GPGMail.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = "MimeBody+GPGMail.h"; sourceTree = "<group>"; };
 		559A805E0838E8300052F47C /* MimePart+GPGMail.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = "MimePart+GPGMail.h"; sourceTree = "<group>"; };
@@ -2683,6 +2686,7 @@
 				1BB3DCCD1407F1CA00870DEB /* LibraryStore+GPGMail.m */,
 				1BAEF64313E9F57700A59CED /* MailAccount+GPGMail.m */,
 				1B8289FA13FD62880007E6A2 /* Message+GPGMail.m */,
+				45E7111D15064ECB00407F7D /* MimePartResult.m */,
 				559A80780838E9B10052F47C /* MimeBody+GPGMail.m */,
 				559A80790838E9B10052F47C /* MimePart+GPGMail.m */,
 			);
@@ -2697,6 +2701,7 @@
 				1BB3DCCC1407F1CA00870DEB /* LibraryStore+GPGMail.h */,
 				1BAEF64213E9F57700A59CED /* MailAccount+GPGMail.h */,
 				1B8289F913FD62880007E6A2 /* Message+GPGMail.h */,
+				45E7111C15064EBE00407F7D /* MimePartResult.h */,
 				559A805D0838E8300052F47C /* MimeBody+GPGMail.h */,
 				559A805E0838E8300052F47C /* MimePart+GPGMail.h */,
 			);
@@ -3115,6 +3120,7 @@
 				1B89E21614FC40F00012D4AD /* NSWindow+GPGMail.m in Sources */,
 				1B2341DE14FEEC8C0007EB64 /* GMSecurityMethodAccessoryView.m in Sources */,
 				303F16161500EB5C002AC36B /* NSButton+LinkCursor.m in Sources */,
+				45E7111E15064ECB00407F7D /* MimePartResult.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3361,7 +3367,6 @@
 					dynamic_lookup,
 				);
 				SDKROOT = macosx;
-				SYMROOT = build;
 				VALID_ARCHS = "x86_64 i386";
 			};
 			name = Debug;
@@ -3403,7 +3408,6 @@
 					dynamic_lookup,
 				);
 				SDKROOT = macosx;
-				SYMROOT = build;
 				VALID_ARCHS = "x86_64 i386";
 			};
 			name = Release;

--- a/GPGMail.xcodeproj/xcshareddata/xcschemes/GPGMail.xcscheme
+++ b/GPGMail.xcodeproj/xcshareddata/xcschemes/GPGMail.xcscheme
@@ -61,6 +61,9 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
+      <PathRunnable
+         FilePath = "/Applications/Mail.app">
+      </PathRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Source/MimePart+GPGMail.h
+++ b/Source/MimePart+GPGMail.h
@@ -31,7 +31,7 @@
 #import <MimePart.h>
 #import <Libmacgpg/Libmacgpg.h>
 
-@class MimeBody;
+@class MimeBody, MimePartResult;
 
 #define PGP_ATTACHMENT_EXTENSION @"pgp"
 #define PGP_PART_MARKER_START @"::gpgmail-start-pgp-part::"
@@ -160,7 +160,7 @@ typedef enum {
  Is called by GPGDecodeWithContext if a multipart/encrypted mime part
  is found. Performs the decryption and returns the result.
  */
-- (id)decodeMultipartEncryptedWithContext:(id)ctx;
+- (id)decodeMultipartEncryptedWithContext:(id)ctx toResult:(MimePartResult*)result;
 
 /**
  Fixes an issue with a very early alpha of GPGMail 2.0
@@ -203,13 +203,17 @@ typedef enum {
 /**
  Creates a new message similar the way S/MIME does it, from the decryptedData.
  */
-- (MimeBody *)decryptedMessageBodyFromDecryptedData:(NSData *)decryptedData;
+- (MimeBody *)decryptedMessageBodyFromDecryptedData:(NSData *)decryptedData
+                                           toResult:(MimePartResult *)result;
 
 /**
  Returns the complete part data but replaces the encrypted data with the decrypted
  first or leaves the encrypted data in, if there was an decryption error.
  */
-- (NSData *)partDataByReplacingEncryptedData:(NSData *)originalPartData decryptedData:(NSData *)decryptedData encryptedRange:(NSRange)encryptedRange;
+- (NSData *)partDataByReplacingEncryptedData:(NSData *)originalPartData 
+                               decryptedData:(NSData *)decryptedData 
+                              encryptedRange:(NSRange)encryptedRange
+                                    toResult:(MimePartResult *)result;
 
 /**
  Calls decryptData: for either PGP/MIME or PGP/Inline encrypted data.

--- a/Source/MimePartResult.h
+++ b/Source/MimePartResult.h
@@ -1,0 +1,56 @@
+/*
+ MimePartResult.h
+ GPGMail
+ 
+ Copyright (c) 2012 Chris Fraire. All rights reserved.
+ 
+ Libmacgpg is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class MimeBody, MFError;
+
+// in order to defer assigning to MimePart results until the last moment before 
+// returning MADecodeWithContext, write to a custom object passed between
+// routines
+@interface MimePartResult : NSObject {
+    MimeBody *decryptedMessageBody_;
+    MimeBody *decryptedBody_;
+    NSData *decryptedData_;
+    NSString *decryptedContent_;
+    NSNumber *isPGPSigned_;
+    NSNumber *isPGPEncrypted_;
+    NSNumber *isPGPDecrypted_;
+    NSNumber *isPGPVerified_;
+    NSNumber *isPGPPartlySigned_;
+    NSNumber *isPGPPartlyEncrypted_;
+    NSArray *pgpSignatures_;
+    MFError *pgpError_;
+}
+
+@property (retain) MimeBody *decryptedMessageBody;
+@property (retain) MimeBody *decryptedBody;
+@property (retain) NSData *decryptedData;
+@property (retain) NSString *decryptedContent;
+@property (retain) NSNumber *isPGPSigned;
+@property (retain) NSNumber *isPGPEncrypted;
+@property (retain) NSNumber *isPGPDecrypted;
+@property (retain) NSNumber *isPGPVerified;
+@property (retain) NSNumber *isPGPPartlySigned;
+@property (retain) NSNumber *isPGPPartlyEncrypted;
+@property (retain) NSArray *pgpSignatures;
+@property (retain) MFError *pgpError;
+
+@end

--- a/Source/MimePartResult.m
+++ b/Source/MimePartResult.m
@@ -1,0 +1,59 @@
+/*
+ MimePartResult.m
+ GPGMail
+ 
+ Copyright (c) 2012 Chris Fraire. All rights reserved.
+ 
+ Libmacgpg is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import "MimePartResult.h"
+
+@implementation MimePartResult
+
+@synthesize decryptedMessageBody=decryptedMessageBody_;
+@synthesize decryptedBody=decryptedBody_;
+@synthesize decryptedData=decryptedData_;
+@synthesize decryptedContent=decryptedContent_;
+@synthesize isPGPSigned=isPGPSigned_;
+@synthesize isPGPEncrypted=isPGPEncrypted_;
+@synthesize isPGPDecrypted=isPGPDecrypted_;
+@synthesize isPGPVerified=isPGPVerified_;
+@synthesize isPGPPartlySigned=isPGPPartlySigned_;
+@synthesize isPGPPartlyEncrypted=isPGPPartlyEncrypted_;
+@synthesize pgpSignatures=pgpSignatures_;
+@synthesize pgpError=pgpError_;
+
+- (id)init {
+    if ((self = [super init])) {
+    }
+    return self;
+}
+
+- (void)dealloc {
+    self.decryptedMessageBody = nil;
+    self.decryptedBody = nil;
+    self.decryptedData = nil;
+    self.decryptedContent = nil;
+    self.isPGPSigned = nil;
+    self.isPGPEncrypted = nil;
+    self.isPGPDecrypted = nil;
+    self.isPGPPartlySigned = nil;
+    self.isPGPPartlyEncrypted = nil;
+    self.pgpSignatures = nil;
+    self.pgpError = nil;
+    [super dealloc];
+}
+
+@end


### PR DESCRIPTION
Hi. This contribution combats the event storms in MimePart decodeWithContext
and verifySignature.
- using a class, MimePartResult, to collect work done in decrypting
  and then to write in key-values before returning from MADecodeWithContext.
- remove an unnecessary set of MimeSigned in MAVerifySignature
- some key-values are used as cache markers (e.g., PGPDecryptedBody,
  PGPVerified), so write to those first before other properties so
  that any triggered re-runs almost certainly get cached results
