### PR TITLE
Recognize more GPGErrorCode values for localized "corrupted message" string

### DIFF
--- a/GPGMail.xcodeproj/project.pbxproj
+++ b/GPGMail.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		3057F2EB1507C9C000FA3C0D /* Special.html in Resources */ = {isa = PBXBuildFile; fileRef = 3057F2E91507C9C000FA3C0D /* Special.html */; };
 		30744AB512B9733800CC3EC5 /* MessageContentController+GPGMail.m in Sources */ = {isa = PBXBuildFile; fileRef = 559A808C0838EA1C0052F47C /* MessageContentController+GPGMail.m */; };
 		30E6857B13FFAC0800563BA5 /* GPGVersionComparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 30E6857A13FFAC0800563BA5 /* GPGVersionComparator.m */; };
+		4555EA4B150922DF00723E1F /* GPGException+GPGMail.m in Sources */ = {isa = PBXBuildFile; fileRef = 4555EA4A150922DF00723E1F /* GPGException+GPGMail.m */; };
 		559A81300838EEFD0052F47C /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559A812B0838EEFD0052F47C /* AddressBook.framework */; };
 		559A81310838EEFD0052F47C /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559A812C0838EEFD0052F47C /* Carbon.framework */; };
 		559A81320838EEFD0052F47C /* Message.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559A812D0838EEFD0052F47C /* Message.framework */; };
@@ -1365,6 +1366,8 @@
 		30FC04EC14FFE61100AA19FE /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/GPGSignatureView.xib.strings; sourceTree = "<group>"; };
 		30FC04EE14FFE61100AA19FE /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/SignatureView.strings; sourceTree = "<group>"; };
 		32DBCF630370AF2F00C91783 /* GPGMail_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GPGMail_Prefix.pch; sourceTree = "<group>"; };
+		4555EA49150922DF00723E1F /* GPGException+GPGMail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GPGException+GPGMail.h"; sourceTree = "<group>"; };
+		4555EA4A150922DF00723E1F /* GPGException+GPGMail.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GPGException+GPGMail.m"; sourceTree = "<group>"; };
 		559A80550838E8300052F47C /* GPGMailPreferences.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = GPGMailPreferences.h; sourceTree = "<group>"; };
 		559A805D0838E8300052F47C /* MimeBody+GPGMail.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = "MimeBody+GPGMail.h"; sourceTree = "<group>"; };
 		559A805E0838E8300052F47C /* MimePart+GPGMail.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = "MimePart+GPGMail.h"; sourceTree = "<group>"; };
@@ -2693,6 +2696,8 @@
 			children = (
 				307E1C6612B17CFF0012F3DF /* GPGMailBundle.h */,
 				30E6857913FFAC0800563BA5 /* GPGVersionComparator.h */,
+				4555EA49150922DF00723E1F /* GPGException+GPGMail.h */,
+				4555EA4A150922DF00723E1F /* GPGException+GPGMail.m */,
 				1BB3DCCC1407F1CA00870DEB /* LibraryStore+GPGMail.h */,
 				1BAEF64213E9F57700A59CED /* MailAccount+GPGMail.h */,
 				1B8289F913FD62880007E6A2 /* Message+GPGMail.h */,
@@ -3113,6 +3118,7 @@
 				1B45481A14F7D0F0000F1646 /* GMSecurityHistory.m in Sources */,
 				1B89E21614FC40F00012D4AD /* NSWindow+GPGMail.m in Sources */,
 				1B2341DE14FEEC8C0007EB64 /* GMSecurityMethodAccessoryView.m in Sources */,
+				4555EA4B150922DF00723E1F /* GPGException+GPGMail.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/GPGException+GPGMail.h
+++ b/Source/GPGException+GPGMail.h
@@ -1,0 +1,28 @@
+/*
+ GPGException+GPGMail.h
+ GPGMail
+ 
+ Copyright (c) 2012 Chris Fraire. All rights reserved.
+ 
+ GPGMail is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import <Libmacgpg/GPGException.h>
+
+@interface GPGException (GPGMail)
+
+// Returns TRUE if the error code qualifies as "corrupted data"
+- (BOOL)isCorruptedInputError;
+
+@end

--- a/Source/GPGException+GPGMail.m
+++ b/Source/GPGException+GPGMail.m
@@ -1,0 +1,37 @@
+/*
+ GPGException+GPGMail.h
+ GPGMail
+ 
+ Copyright (c) 2012 Chris Fraire. All rights reserved.
+ 
+ GPGMail is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import "GPGException+GPGMail.h"
+
+@implementation GPGException (GPGMail)
+
+- (BOOL)isCorruptedInputError {
+    switch (self.errorCode) {
+        case GPGErrorUnknownPacket:
+        case GPGErrorChecksumError:
+        case GPGErrorInvalidPacket:
+        case GPGErrorInvalidArmor:
+            return TRUE;
+        default:
+            return FALSE;
+    }
+}
+
+@end

--- a/Source/MimePart+GPGMail.h
+++ b/Source/MimePart+GPGMail.h
@@ -345,10 +345,5 @@ typedef enum {
  */
 - (void)failedToSignForSender:(NSString *)sender gpgErrorCode:(GPGErrorCode)errorCode;
 
-/**
- Determine if errorCode qualifies for localized "corrupted message" 
- */
-- (BOOL)isCorruptedInputException:(GPGException *)error;
-
 @end
 

--- a/Source/MimePart+GPGMail.m
+++ b/Source/MimePart+GPGMail.m
@@ -34,6 +34,7 @@
 #import "NSArray+Functional.h"
 #import "NSObject+LPDynamicIvars.h"
 #import "GPGFlaggedString.h"
+#import "GPGException+GPGMail.h"
 #import "MimePart+GPGMail.h"
 #import "MimeBody+GPGMail.h"
 #import "NSString+GPGMail.h"
@@ -629,7 +630,7 @@
     }
     else if([self hasError:@"NO_ARMORED_DATA" noDataErrors:noDataErrors] || 
             [self hasError:@"INVALID_PACKET" noDataErrors:noDataErrors] || 
-            [self isCorruptedInputException:(GPGException *)operationError]) {
+            [(GPGException *)operationError isCorruptedInputError]) {
         titleKey = [NSString stringWithFormat:@"%@_DECRYPT_CORRUPTED_DATA_ERROR_TITLE", prefix];
         messageKey = [NSString stringWithFormat:@"%@_DECRYPT_CORRUPTED_DATA_ERROR_MESSAGE", prefix];
         
@@ -655,18 +656,6 @@
     [userInfo release];
     
     return error;
-}
-
-- (BOOL)isCorruptedInputException:(GPGException *)error {
-    switch (error.errorCode) {
-        case GPGErrorUnknownPacket:
-        case GPGErrorChecksumError:
-        case GPGErrorInvalidPacket:
-        case GPGErrorInvalidArmor:
-            return TRUE;
-        default:
-            return FALSE;
-    }
 }
 
 - (MFError *)errorFromVerificationOperation:(GPGController *)gpgc {


### PR DESCRIPTION
This allows the TestCases to indicate the localized "corrupted message" string instead of the localized "failed with unknown error."
