### PR TITLE
Catch the GPGException that can be thrown by the underlying GPGPacket ca...

### DIFF
--- a/Source/MimePart+GPGMail.m
+++ b/Source/MimePart+GPGMail.m
@@ -526,8 +526,14 @@
     // Decrypt data should not run if Mail.app is generating snippets
     // and NeverCreateSnippetPreviews is set or the passphrase is not in cache
     // and CreatePreviewSnippets is not set.
-    if(![[(MimeBody *)[self mimeBody] message] shouldCreateSnippetWithData:encryptedData])    
+    @try {
+        if(![[(MimeBody *)[self mimeBody] message] shouldCreateSnippetWithData:encryptedData])
+            return nil;
+    }
+    @catch(GPGException *e) {
+        [self failedToSignForSender:sender gpgErrorCode:e.errorCode];
         return nil;
+    }
     
     GPGController *gpgc = [[GPGController alloc] init];
     gpgc.verbose = NO;


### PR DESCRIPTION
I think that this patch will catch the unhandled exception, log an error, and return nil like an existing error case already does. See http://gpgtools.lighthouseapp.com/projects/65764-gpgmail/tickets/544 for the bug I created earlier today.
