### PR TITLE
Catch the GPGException that can be thrown by the underlying GPGPacket ca...

### DIFF
--- a/Source/MimePart+GPGMail.m
+++ b/Source/MimePart+GPGMail.m
@@ -526,8 +526,14 @@
     // Decrypt data should not run if Mail.app is generating snippets
     // and NeverCreateSnippetPreviews is set or the passphrase is not in cache
     // and CreatePreviewSnippets is not set.
-    if(![[(MimeBody *)[self mimeBody] message] shouldCreateSnippetWithData:encryptedData])    
+    @try {
+        if(![[(MimeBody *)[self mimeBody] message] shouldCreateSnippetWithData:encryptedData])
+            return nil;
+    }
+    @catch(GPGException *e) {
+        [self failedToSignForSender:@"t@t.com" gpgErrorCode:e.errorCode];
         return nil;
+    }
     
     GPGController *gpgc = [[GPGController alloc] init];
     gpgc.verbose = NO;


### PR DESCRIPTION
This change fixes the uncaught GPGException that is the cause of the crash in [ticket #544](http://gpgtools.lighthouseapp.com/projects/65764/tickets/544-uncaught-gpgexception-crashes-mailapp#ticket-544-1)
