### PR TITLE
fix German wording for signature status

### DIFF
--- a/Resources/de.lproj/SignatureView.strings
+++ b/Resources/de.lproj/SignatureView.strings
@@ -8,13 +8,13 @@
  Defines the strings used in the signature view.
  */
 "VALIDITY_NO_TRUST" = "Diese Signatur ist nicht vertrauenswürig.";
-"VALIDITY_OK" = "Diese Signature ist vertrauenswürdig";
+"VALIDITY_OK" = "Diese Signatur ist vertrauenswürdig.";
 /* Signature view key status. */
 "VALIDITY_KEY_REVOKED" = "Der Schlüssel dieser Signatur wurde widerrufen.";
 "VALIDITY_SIGNATURE_EXPIRED" = "Diese Signatur ist abgelaufen.";
 "VALIDITY_KEY_EXPIRED" = "Der Schlüssel dieser Signatur ist abgelaufen.";
 "VALIDITY_KEY_REVOKED" = "Der Schlüssel dieser Signatur wurde widerrufen.";
-"VALIDITY_UNKNOWN_ALGORITHM" = "Signatur wurde mit unbekanntem Algorithmus erstellt.";
-"VALIDITY_NO_PUBLIC_KEY" = "Schlüssel dieser Signatur befindet sich nicht im Schlüsselbund.";
+"VALIDITY_UNKNOWN_ALGORITHM" = "Die Signatur wurde mit einem unbekannten Algorithmus erstellt.";
+"VALIDITY_NO_PUBLIC_KEY" = "Der Schlüssel dieser Signatur befindet sich nicht im Schlüsselbund.";
 "VALIDITY_UNKNOWN_ERROR" = "Unbekannter Signatur Fehler.";
 "VALIDITY_BAD_SIGNATURE" = "Diese Signatur ist ungültig.";


### PR DESCRIPTION
I fixed the use of the English “signature” in otherwise German text for the very common signature valid message. I also changed some incomplete sentences.
