### PR TITLE
Fix french translation

### DIFF
--- a/Resources/fr.lproj/GPGMail.strings
+++ b/Resources/fr.lproj/GPGMail.strings
@@ -18,16 +18,16 @@
 "MESSAGE_BANNER_PGP_DECRYPT_SECKEY_ERROR_MESSAGE" = "Aucune des clés secrètes suivantes n'a été trouvée dans votre trousseau de clés (%@). La clé secrète est nécessaire pour déchiffrer ce message.\n\nVeuillez vérifier avec l'expéditeur qu'il a utilisé la bonne clé publique.\nVérifiez les sauvegardes de votre trousseau pour essayer d'en importer votre clé privée.";
 
 "MESSAGE_BANNER_PGP_DECRYPT_SYSTEM_ERROR_TITLE" = "Le déchiffrement a échoué sur une erreur inconnue !";
-"MESSAGE_BANNER_PGP_DECRYPT_SYSTEM_ERROR_MESSAGE" = "Une erreur est survenue lors de la décryptation du message.\n\nVeuillez nous contacter à l'adresse suivante https://gpgtools.tenderapp.com";
+"MESSAGE_BANNER_PGP_DECRYPT_SYSTEM_ERROR_MESSAGE" = "Une erreur est survenue lors du déchiffrement du message.\n\nVeuillez nous contacter à l'adresse suivante https://gpgtools.tenderapp.com";
 
-"MESSAGE_BANNER_PGP_DECRYPT_GENERAL_ERROR_TITLE" = "Décryptation échouée pour une raison inconnue!";
+"MESSAGE_BANNER_PGP_DECRYPT_GENERAL_ERROR_TITLE" = "Déchiffrement échoué pour une raison inconnue!";
 "MESSAGE_BANNER_PGP_DECRYPT_GENERAL_ERROR_MESSAGE" = "Une erreur inconnue est survenue lors du déchiffrement du message.\n\nMessage de l'erreur GPG:\n%@\nVeuillez nous contacter, en renseignant le message d'erreur GPG à l'adresse https://gpgtools.tenderapp.com";
 
 "MESSAGE_BANNER_PGP_DECRYPT_WRONG_SECKEY_ERROR_TITLE" = "Clé erronée utilisée pour chiffrer ce message.";
 "MESSAGE_BANNER_PGP_DECRYPT_WRONG_SECKEY_ERROR_MESSAGE" = "Ce message n'a pu être déchiffré car une clé publique erronée a été utilisée pour le chiffrer.\n\nMerci de nous contacter sur https://gpgtools.tenderapp.com";
 
-"MESSAGE_BANNER_PGP_DECRYPT_CORRUPTED_DATA_ERROR_TITLE" = "Le message crypté est endommagé";
-"MESSAGE_BANNER_PGP_DECRYPT_CORRUPTED_DATA_ERROR_MESSAGE" = "Le message crypté est endommagé et ne peut être décrypté.\n\nVeuillez demander à l'expéditeur de l'envoyer à nouveau.";
+"MESSAGE_BANNER_PGP_DECRYPT_CORRUPTED_DATA_ERROR_TITLE" = "Le message chiffré est endommagé";
+"MESSAGE_BANNER_PGP_DECRYPT_CORRUPTED_DATA_ERROR_MESSAGE" = "Le message chiffré est endommagé et ne peut être déchiffré.\n\nVeuillez demander à l'expéditeur de l'envoyer à nouveau.";
 
 "MESSAGE_BANNER_PGP_VERIFY_REVOKED_CERTIFICATE_ERROR_TITLE" = "La clé de la signature a été révoquée.";
 "MESSAGE_BANNER_PGP_VERIFY_REVOKED_CERTIFICATE_ERROR_MESSAGE" = "ATTENTION: La clé utilisée pour signer ce message a été révoquée.\n\nVous devriez rafraichir la clé avec l'identifiant de clé %@ dans GPG Keychain pour vérifier si une clé plus récente est disponible. Si la nouvelle est également révoquée, vérifiez la raison de la révocation auprès de l'expéditeur.";
@@ -113,9 +113,9 @@
 "MESSAGE_BANNER_PGP_ATTACHMENT_VERIFY_SIGNATURE_EXPIRED_ERROR_TITLE" = "La signature du fichier joint est expirée.";
 "MESSAGE_BANNER_PGP_ATTACHMENT_VERIFY_SIGNATURE_EXPIRED_ERROR_MESSAGE" = "La signature du fichier joint est expirée et n'a pu être vérifiée.\n\nDemandez à l'expéditeur la raison de son expiration.";
 
-"MESSAGE_IS_PGP_PARTLY_ENCRYPTED" = "Partiellement crypté";
+"MESSAGE_IS_PGP_PARTLY_ENCRYPTED" = "Partiellement chiffré";
 "MESSAGE_IS_PGP_PARTLY_SIGNED" = "Partiellement signé";
-"MESSAGE_IS_PGP_ENCRYPTED" = "Crypté";
+"MESSAGE_IS_PGP_ENCRYPTED" = "Chiffré";
 "MESSAGE_IS_PGP_SIGNED" = "Signé";
 "MESSAGE_IS_PGP_SIGNED_INVALID" = "Signature non valide";
 
@@ -127,20 +127,20 @@
 "MESSAGE_SECURITY_HEADER_NO_SIGNATURE_TITLE" = "Aucune signature trouvée";
 
 /* Security header attachments related. */
-"MESSAGE_SECURITY_HEADER_ATTACHMENT_SIGNED_ENCRYPTED_TITLE" = "fichier joint crypté/signé";
-"MESSAGE_SECURITY_HEADER_ATTACHMENTS_SIGNED_ENCRYPTED_TITLE" = "fichiers joints cryptés/signés";
-"MESSAGE_SECURITY_HEADER_ATTACHMENT_ENCRYPTED_TITLE" = "fichier joint crypté";
-"MESSAGE_SECURITY_HEADER_ATTACHMENTS_ENCRYPTED_TITLE" = "fichiers joints cryptés";
+"MESSAGE_SECURITY_HEADER_ATTACHMENT_SIGNED_ENCRYPTED_TITLE" = "fichier joint chiffré/signé";
+"MESSAGE_SECURITY_HEADER_ATTACHMENTS_SIGNED_ENCRYPTED_TITLE" = "fichiers joints chiffrés/signés";
+"MESSAGE_SECURITY_HEADER_ATTACHMENT_ENCRYPTED_TITLE" = "fichier joint chiffré";
+"MESSAGE_SECURITY_HEADER_ATTACHMENTS_ENCRYPTED_TITLE" = "fichiers joints chiffrés";
 "MESSAGE_SECURITY_HEADER_ATTACHMENT_SIGNED_TITLE" = "fichier joint signé";
 "MESSAGE_SECURITY_HEADER_ATTACHMENTS_SIGNED_TITLE" = "fichiers joints signés";
 
 /* Compose Window encrypt/sign button tooltips. */
 "COMPOSE_WINDOW_TOOLTIP_CAN_NOT_PGP_SIGN" = "Ce message ne peut-être signé car il n'existe pas de clé privée pour %@.\n\nMerci de vous assurer qu'une clé privée existe pour cette adresse dans GPG Keychain. Ajouter si nécessaire un nouvel UID à une clé existante pour cette adresse, ou créez une nouvelle clé pour cette adresse.\n\nSi une clé existe pour cette adresse, merci de vous assurer que l'adresse est correctement saisie dans les préférences de Mail et correspond exactment à l'adresse de la clé.";
-"COMPOSE_WINDOW_TOOLTIP_CAN_NOT_PGP_ENCRYPT" = "Ce message ne peut être crypté, il n'existe pas de clés publiques disponibles pour les adresses suivantes: %@.\n\nVeuillez utiliser GPG Keychain pour rechercher et importer les clés pour ces adresses.";
-"COMPOSE_WINDOW_TOOLTIP_CAN_NOT_PGP_ENCRYPT_NO_RECIPIENTS" = "Ce message ne peut être crypté. Vous devez d'abord indiquer un destinataire.";
+"COMPOSE_WINDOW_TOOLTIP_CAN_NOT_PGP_ENCRYPT" = "Ce message ne peut être chiffré, il n'existe pas de clés publiques disponibles pour les adresses suivantes: %@.\n\nVeuillez utiliser GPG Keychain pour rechercher et importer les clés pour ces adresses.";
+"COMPOSE_WINDOW_TOOLTIP_CAN_NOT_PGP_ENCRYPT_NO_RECIPIENTS" = "Ce message ne peut être chiffré. Vous devez d'abord indiquer un destinataire.";
 
 /* Message view pgp part. */
-"MESSAGE_VIEW_PGP_PART_ENCRYPTED" = "Crypté";
+"MESSAGE_VIEW_PGP_PART_ENCRYPTED" = "Chiffré";
 "MESSAGE_VIEW_PGP_PART_SIGNED" = "Signé";
 "MESSAGE_VIEW_PGP_PART" = "partie PGP";
 
@@ -151,8 +151,8 @@
 "GPG_STATUS_NOT_FOUND_TOOLTIP" = "Veuillez télécharger l'utilitaire d'installation GPGTools à partir de l'adresse http://www.gpgtools.org pour installer GPGTools";
 "GPG_STATUS_OTHER_ERROR_TITLE" = "Veuillez vérifier votre installation et configuration.";
 "GPG_STATUS_NOT_FOUND_TOOLTIP" = "Veuillez télécharger l'utilitaire d'installation GPGTools à partir de l'adresse http://www.gpgtools.org pour installer GPGTools";
-"DISABLE_ENCRYPT_DRAFTS_TITLE" = "Warning: Disabling this option might lead to the leak of sensitive information while composing a message";
-"DISABLE_ENCRYPT_DRAFTS_MESSAGE" = "If the option \"Store drafts on server\" is enabled for your accounts, OS X Mail automatically stores your drafts on your mail server while you're composing a message.\nBy disabling\"Encrypt drafts\", your drafts will be stored in plain text (not encrypted) so that anyone with access to the mail server can read them.\n\nIf you keep \"Encrypt drafts\" enabled, your drafts will be encrypted before they are stored on a mail server and only you will be able to read them.\n\nDo you still want want to disable \"Encrypt drafts\"?";
+"DISABLE_ENCRYPT_DRAFTS_TITLE" = "Avertissemement : désactiver cette option pourrait provoquer la révélation d'informations sensibles lorsque vous composez un message";
+"DISABLE_ENCRYPT_DRAFTS_MESSAGE" = "Si l'option \"Stocker les brouillons sur le serveur\" est activée pour vos comptes, OS X Mail stocke automatiquement vos brouillons sur votre serveur de courrier pendant que vous composez un message.\nEn désactivant \"Chiffrer les brouillons\", vos brouillons seront stockés en texte clair (non chiffré), de sorte que quiconque a accès au serveur pourra les lire.\n\nSi vous gardez \"Chiffrer les brouillons\" activée, vos brouillons seront chiffrés avant d'être stockés sur le serveur de courrier, et vous seul serez en mesure de les lire.\n\nVoulez-vous tout de même désactiver \"Chiffrer les brouillons\"?";
 "DISABLE_ENCRYPT_DRAFTS_CONFIRM" = "Yes";
 
 
@@ -224,12 +224,12 @@ NO_DEFAULTS_MESSAGE = "GPGMail ne fonctionne pas comme attendu.\n\nMerci de tél
 "MESSAGE_BANNER_PGP_ATTACHMENT_DECRYPT_ERROR_PINENTRY_CRASHED_TITLE" = "Le déchiffrement de la pièce jointe a échoué à cause d'un dispositif de saisie de PIN défectueux.";
 "MESSAGE_BANNER_PGP_ATTACHMENT_DECRYPT_ERROR_PINENTRY_CRASHED_MESSAGE" = "Le dispositif d'entrée de PIN responsable de la saisie de votre mot de passe ne fonctionne pas correctement.\n\nPour résoudre ce problème, merci de télécharger et ré-installer la suite GPG depuis https://gpgtools.org\n\n";
 
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_TITLE" = "Attention: You're about to send an unencrypted reply to an encrypted message";
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_MISSING_KEYS_SINGULAR" = "It's not possible to encrypt your reply, because the public key for the following recipient is missing:\n\n%@";
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_MISSING_KEYS" = "It's not possible to encrypt your reply, because public keys for the following recipients are missing:\n\n%@";
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_EXPLANATION" = "If you choose to proceed, your reply will be sent unencrypted. As a result, confidential information might be leaked, putting you and your recipients at risk.";
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_SOLUTION_REMOVE_PREVIOUS_CORRESPONDENCE" = "\n\nIf you really wish to send this reply unencrypted, please remove any previous correspondence included in your reply prior to sending.";
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_SOLUTION_IMPORT_KEYS" = "Otherwise, search and import the corresponding public keys using GPG Keychain in order to send the reply encrypted.";
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_SOLUTION_IMPORT_KEYS_SINGULAR" = "Otherwise, search and import the the corresponding public key using GPG Keychain in order to send the reply encrypted.";
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_BUTTON_SEND_ANYWAY" = "Send Anyway";
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_BUTTON_CANCEL" = "Cancel";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_TITLE" = "Attention: Vous êtes sur le point d'envoyer une réponse en clair à un message chiffré";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_MISSING_KEYS_SINGULAR" = "Il est impossible de chiffrer votre réponse, car la clé publique pour le destinataire suivant est manquante:\n\n%@";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_MISSING_KEYS" = "Il est impossible de chiffrer votre réponse, car les clés publiques pour les destinataires suivants sont manquantes:\n\n%@";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_EXPLANATION" = "Si vous choisissez de continuer, votre réponse sera envoyée en clair. En conséquence, des informations confidentielles pourraient être révélées, vous exposant, vous et vos correspondants, à des risques.";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_SOLUTION_REMOVE_PREVIOUS_CORRESPONDENCE" = "\n\nSi vous souhaitez réellement envoyer cette réponse en clair, supprimez toute correspondance précédente de votre réponse avant de l'envoyer.";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_SOLUTION_IMPORT_KEYS" = "Sinon, recherchez et importez la clé publique correspondante avec GPG Keychain pour envoyer votre réponse chiffrée.";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_SOLUTION_IMPORT_KEYS_SINGULAR" = "Sinon, recherchez et importez les clés publiques correspondantes avec GPG Keychain pour envoyer votre réponse chiffrée.";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_BUTTON_SEND_ANYWAY" = "Envoyer quand-même";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_BUTTON_CANCEL" = "Annuler";

--- a/Resources/fr.lproj/GPGMail.strings
+++ b/Resources/fr.lproj/GPGMail.strings
@@ -231,5 +231,5 @@ NO_DEFAULTS_MESSAGE = "GPGMail ne fonctionne pas comme attendu.\n\nMerci de tél
 "UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_SOLUTION_REMOVE_PREVIOUS_CORRESPONDENCE" = "\n\nSi vous souhaitez réellement envoyer cette réponse en clair, supprimez toute correspondance précédente de votre réponse avant de l'envoyer.";
 "UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_SOLUTION_IMPORT_KEYS" = "Sinon, recherchez et importez la clé publique correspondante avec GPG Keychain pour envoyer votre réponse chiffrée.";
 "UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_SOLUTION_IMPORT_KEYS_SINGULAR" = "Sinon, recherchez et importez les clés publiques correspondantes avec GPG Keychain pour envoyer votre réponse chiffrée.";
-"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_BUTTON_SEND_ANYWAY" = "Envoyer quand-même";
+"UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_BUTTON_SEND_ANYWAY" = "Envoyer quand même";
 "UNENCRYPTED_REPLY_TO_ENCRYPTED_MESSAGE_BUTTON_CANCEL" = "Annuler";


### PR DESCRIPTION
* Get rid of "crypter/décrypter" and "crypté/décrypté", as in french the
correct verbs are "chiffrer" and "déchiffrer"
* Replace "décryptation" (which does not exist at all) with the proper
"déchiffrement"
* Add missing translations