### PR TITLE
Fixes issue where MFMessageRouter is initialized prior to MailAccounts loading

### DIFF
--- a/Source/GMCodeInjector.h
+++ b/Source/GMCodeInjector.h
@@ -32,6 +32,7 @@
 @interface GMCodeInjector : NSObject
 
 + (void)injectUsingMethodPrefix:(NSString *)prefix;
++ (void)injectUsingMethodPrefix:(NSString *)prefix hooks:(NSDictionary*)hooks;
 + (NSDictionary *)hooks;
 
 @end


### PR DESCRIPTION
MFMessageRouter will load rules in its +initialization method -- which is inadvertently 
called during injection because of the runtime lookup of MFMessageRouter.

With the base code in GPGMail, the early initialization of MFMessageRouter takes prior to
accounts being loaded, leading to undetermined effect, including having Mailboxes loading
before accounts are loaded. My experience is that Mailboxes should be set up after Accounts
have been loaded.

A further conflict occur with MailTags because this early initialization will trigger MailTags
to try to load its rules at the same time which may lead to a dead lock (race condition).

This has been a known conflict for some time and I have conversed with Lukas regarding it.

The resolution to this situation is to defer code injection until after Account 
initialization is complete. When GPGMail is loaded, it swizzles the 
completeDeferredAccountInitialization, which is called once accounts are ready to go 
At this point it is safe to load MFMessageRouter and thus safe to swizzle for MessageRouter 
methods

