### PR TITLE
Fix native compatibility with Mail 12.x

### DIFF
--- a/Source/GPGMailBundle.h
+++ b/Source/GPGMailBundle.h
@@ -63,6 +63,12 @@ extern NSString *gpgErrorIdentifier; // This identifier is used to set and find 
 }
 
 /**
+ Expose the initialize function to prevent Mail 12.x
+ rejecting the mailbundle as incompatible
+ */
++ (void)initialize;
+
+/**
  Checks for multiple installations of GPGMail.mailbundle in
  all Library folders.
  */


### PR DESCRIPTION
It appears this one change is all that is needed to fix loading the GPGMail.mailbundle without requiring the GPGMailLoader.mailbundle.

Please accept this pull request so that others can build and run this project without needing to rely on the closed-source mail loader under Mojave