### PR TITLE
Add missing step to build Libmacgpgp dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ make
 #### Install
 Copy Libmacgpg.framework from Dependencies/Libmacgpg/build/Release/ to ~/Library/Frameworks.
 
-After that copy the GPGMail.mailbundle file from build/Releases/GPGMail.mailbundle to ~/Libray/Mail/Bundles, re-start Mail.app and enjoy.
+After that copy the GPGMail.mailbundle file from build/Release/GPGMail.mailbundle to ~/Libray/Mail/Bundles, re-start Mail.app and enjoy.
 
 
 System Requirements

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ make
 #### Install
 Copy Libmacgpg.framework from Dependencies/Libmacgpg/build/Release/ to ~/Library/Frameworks.
 
-After that copy the GPGMail.mailbundle file from build/Release/GPGMail.mailbundle to ~/Libray/Mail/Bundles, re-start Mail.app and enjoy.
+After that copy the GPGMail.mailbundle file from build/Release/GPGMail.mailbundle to ~/Library/Mail/Bundles, re-start Mail.app and enjoy.
 
 
 System Requirements

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ It's necessary to clone the Libmacgpg repository first, before building GPGMail.
 ```bash
 cd Dependencies
 git clone https://github.com/GPGTools/Libmacgpg.git
+make # build Libmacgpgp dependency
 cd ..
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ It's necessary to clone the Libmacgpg repository first, before building GPGMail.
 ```bash
 cd Dependencies
 git clone https://github.com/GPGTools/Libmacgpg.git
-make # build Libmacgpgp dependency
+cd Libmacgpg
+make # build Libmacgpg dependency
 cd ..
 ```
 


### PR DESCRIPTION
Libmacgpgp didn't build automatically when running make at the end.
It needs to be built, otherwise Dependencies/Libmacgpg/build/Release/ doesn't exist.